### PR TITLE
Implemented bankruptcy and game ending.

### DIFF
--- a/Board.py
+++ b/Board.py
@@ -221,7 +221,7 @@ class GameBoard(object):
         color = building.getColor()
         rect = building.getRect()
         name = building.getName()
-        if building.getPurpose() == "academic":
+        if building.getPurpose() == "academic" or building.getOwner() == None:
             pointList = building.getPointList()
         else:    
             pointList = building.getInnerPointList()
@@ -268,7 +268,7 @@ class GameBoard(object):
         for building in buildings:
             if building.getPurpose() == "academic":
                 if building.getDegreeLvl() == "Associate":
-                    break;
+                    continue
                 elif building.getDegreeLvl() == "Bachelor":
                     self.addGradIcons(building, 1)
                 elif building.getDegreeLvl() == "Master":

--- a/Cards.py
+++ b/Cards.py
@@ -15,6 +15,7 @@ class Cards():
         self.loadImages()
 
         self.movementCard = False
+        self.feeCard = False
 
     def getXPosition(self):
         return self.area.get_offset()[0]
@@ -53,7 +54,7 @@ class Cards():
             text = "Hold alumni fundraiser and raise $100,000."
         if card == 3:
             text = "Rap artist arrested. Cancel concert, refund tickets, lose $50,000."
-            
+         
         '''
         if card == 0:
             text = "Move back 3 spaces and stuff. You are going the wrong way."
@@ -74,6 +75,7 @@ class Cards():
     def performAction(self, card, player):
         """Performs the action printed on the card that was drawn."""
         self.player = player    # the player who drew the card
+    
         if card == 0:
             self.goToSpace("Accreditation Review")
         if card == 1:
@@ -82,6 +84,7 @@ class Cards():
             self.player.addDollars(100000)
         if card == 3:
             self.player.subtractDollars(50000)    
+            self.feeCard = True
 
 
     def displayCard(self, card, scale):

--- a/Player.py
+++ b/Player.py
@@ -23,6 +23,7 @@ class Player(object):
         self.ownsPSU = False
         self.ownsBookstore = False
         self.inAccreditationReview = False
+        self.isBankrupt = False
         self.playerToken = Token(self.getColor(), self.position, self.board,
                                  self.allBldgs.getBuildingList(), self.scale)
 

--- a/Turn.py
+++ b/Turn.py
@@ -2,6 +2,7 @@ import pygame
 from pygame.locals import *
 from MessageBox import * # contains displayMsg(), displayMsgOK(), displayMsgYN()
 from CheckBox import CheckBox
+from Building import *
 
 
 class Turn(object):
@@ -53,6 +54,7 @@ class Turn(object):
         Turn.msgSurface = parent.subsurface(Turn.msgRect)
         Turn.smallMsgSurface = parent.subsurface(Turn.smallMsgRect)
         Turn.upgradeSurface = parent.subsurface(Turn.upgradeRect)
+        Turn.gameOver = False
 
 
     def beginTurn(self, extraOrLost, begin = True):
@@ -61,6 +63,9 @@ class Turn(object):
         and giving instructions to roll the dice.  Also, displays messages
         regarding lost or extra turns.
         """
+        # If a player has won, allow the appropriate message to be displayed.
+        if Turn.gameOver:
+            return
 
         # If a player has lost a turn, display this fact.
         if extraOrLost == -1:
@@ -78,8 +83,8 @@ class Turn(object):
         # If the player is in Accreditation Review, display appropriate message.
         if self.player.inAccreditationReview:
             (size, msgBox) = displayMsg(Turn.scale, Turn.smallMsgRect, Turn.msgRect,
-                Turn.font, self.player.getName() + " is stuck in Accreditation "
-                    + "Review. Roll dice to see if you pass.")
+                Turn.font, self.player.getName() + ", you're stuck in "
+                    + "Accreditation Review. Roll dice to see if you pass.")
 
         # If this is a player's extra turn, indicate that.
         elif extraOrLost == 1:
@@ -131,7 +136,8 @@ class Turn(object):
                 + "required improvements and try again next turn.")
             Turn.msgSurface.blit(msgBox, (0, 0))
             self.okMsgDisplayed = True
-            self.player.subtractDollars(100000)
+            self.feeMsgDisplayed = True
+            self.feeAmt = 100000            
 
 
     def handleLanding(self):
@@ -139,6 +145,10 @@ class Turn(object):
         This method handles what comes next after a player lands on a space,
         (e.g., buying the building or paying fees to another player).
         """
+        # If a player has won, allow the appropriate message to be displayed.
+        if Turn.gameOver:
+            return
+        
         self.landed = True
         position = self.player.getPosition()
         self.building = Turn.buildings.getBuildingList()[position]
@@ -435,4 +445,4 @@ class Turn(object):
                     self.player.subtractDollars(250000)
                     self.player.addPointsPerRound(1)
                 building.setDegreeLvl("Doctorate")
-                
+     


### PR DESCRIPTION
When a player goes bankrupt, their buildings become unowned and their section in the display is grayed out.
When the game ends, an appropriate message is displayed. Upon clicking OK, it returns to the Start Menu. Another game can then be started, but currently it doesn't function correctly if you try to change the players.
